### PR TITLE
feat(portable-heading): add linkable headings

### DIFF
--- a/apps/web/src/app/cms/components/portable-text/index.tsx
+++ b/apps/web/src/app/cms/components/portable-text/index.tsx
@@ -6,6 +6,7 @@ import { TinaMarkdown } from 'tinacms/dist/rich-text'
 import { PortableButton } from './portable-button'
 import { PortableCode } from './portable-code'
 import { PortableContactForm } from './portable-contact-form'
+import { PortableHeading } from './portable-heading'
 import { PortableImage } from './portable-image'
 import { PortableLink } from './portable-link'
 
@@ -19,6 +20,10 @@ function PortableText(props: ExtractProps<typeof TinaMarkdown>) {
 					ContactForm: PortableContactForm,
 					code_block: PortableCode,
 					image: PortableImage,
+					h1: PortableHeading,
+					h2: PortableHeading,
+					h3: PortableHeading,
+					h4: PortableHeading,
 					a: PortableLink,
 				} as any
 			}

--- a/apps/web/src/app/cms/components/portable-text/portable-heading.tsx
+++ b/apps/web/src/app/cms/components/portable-text/portable-heading.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { Button } from '@nerdfish/ui'
+import { cx } from '@nerdfish/utils'
+import { Icons } from '@nerdfish-website/ui/icons'
+import * as React from 'react'
+import slugify from 'slugify'
+
+export function PortableHeading({
+	children,
+	type,
+}: {
+	children?: React.ReactElement
+	type: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6'
+}) {
+	const [hasCopied, setHasCopied] = React.useState(false)
+
+	React.useEffect(() => {
+		setTimeout(() => {
+			setHasCopied(false)
+		}, 2000)
+	}, [hasCopied])
+
+	if (!children) return null
+
+	const textNode = children.props.content.find(
+		(node: any) => node.type === 'text',
+	)
+
+	const Heading = type
+	const id = textNode?.text
+		? slugify(textNode.text, { lower: true })
+		: undefined
+
+	return (
+		<Heading id={id} className="group flex items-center">
+			{children}
+			{type === 'h2' && id ? (
+				<Button
+					variant="ghost"
+					size="iconSm"
+					className={cx(
+						'text-nerdfish ml-2 hidden group-hover:flex',
+						hasCopied && 'flex',
+					)}
+					onClick={async () => {
+						const url = `${window.location.origin}${window.location.pathname}#${id}`
+						await navigator.clipboard.writeText(url)
+						setHasCopied(true)
+					}}
+					aria-label="Link to this section"
+				>
+					<span className="sr-only">Copy</span>
+					{hasCopied ? (
+						<Icons.Check className="text-success size-4" />
+					) : (
+						<Icons.Link className="size-4" />
+					)}
+				</Button>
+			) : null}
+		</Heading>
+	)
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `PortableHeading` components for `h1` to `h4` tags within the text editor.
  - Added copy-to-clipboard functionality for section links in headings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->