### PR TITLE
ci(format): remove tina build

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -28,9 +28,6 @@ jobs:
       - name: Install
         uses: ./packages/github-actions/install
 
-      - name: Build for types
-        run: pnpm build:tina
-
       - name: Run format
         run: pnpm format
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Streamlined the GitHub Actions workflow by removing the "Build for types" step from the "format" job, enhancing job execution efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->